### PR TITLE
Drop metadata from optimized SVG

### DIFF
--- a/logo/foreman-web.svg
+++ b/logo/foreman-web.svg
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" style="enable-background:new" xmlns="http://www.w3.org/2000/svg" version="1.0" xmlns:cc="http://creativecommons.org/ns#" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 255.42 194.27" xmlns:dc="http://purl.org/dc/elements/1.1/">
-<title>Foreman Icon</title>
 <defs>
 <linearGradient id="f">
 <stop stop-opacity=".33" offset="0"/>
@@ -87,51 +86,6 @@
 <linearGradient id="z" y2="-126.74" xlink:href="#b" gradientUnits="userSpaceOnUse" x2="231.25" gradientTransform="matrix(1.7961 .15639 -.18211 1.8417 -200.4 376.29)" y1="-126.74" x1="227.5"/>
 <radialGradient id="i" xlink:href="#g" gradientUnits="userSpaceOnUse" cy="56.483" cx="80.689" gradientTransform="matrix(-1.103 .051042 -.012944 -.27972 245.26 81.24)" r="81.578"/>
 </defs>
-<metadata>
-<rdf:RDF>
-<cc:Work rdf:about="">
-<dc:format>image/svg+xml</dc:format>
-<dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-<dc:creator>
-<cc:Agent>
-<dc:title>Máirín Duffy Strode</dc:title>
-</cc:Agent>
-</dc:creator>
-<dc:source/>
-<cc:license rdf:resource=""/>
-<dc:title>Foreman Icon</dc:title>
-<dc:subject>
-<rdf:Bag>
-<rdf:li>foreman</rdf:li>
-<rdf:li>puppet</rdf:li>
-<rdf:li>management</rdf:li>
-<rdf:li>systems</rdf:li>
-</rdf:Bag>
-</dc:subject>
-<dc:date>25 May 2011</dc:date>
-<dc:rights>
-<cc:Agent>
-<dc:title/>
-</cc:Agent>
-</dc:rights>
-<dc:publisher>
-<cc:Agent>
-<dc:title/>
-</cc:Agent>
-</dc:publisher>
-<dc:identifier/>
-<dc:relation/>
-<dc:language/>
-<dc:coverage/>
-<dc:description/>
-<dc:contributor>
-<cc:Agent>
-<dc:title>Lapo Calamandrei (used some parts from Gimp devel icon)</dc:title>
-</cc:Agent>
-</dc:contributor>
-</cc:Work>
-</rdf:RDF>
-</metadata>
 <g transform="translate(-20.053 -61.124)">
 <path opacity=".53571" d="m47.518 190.59c-24.662 7.3484 30.107 42.063 53.215 48.765 47.108 13.663 77.728 17.467 144.85-25.938 27.101-23.941-19.54-25.35-81.132-21.376-104.14-5.57-111.78-21.09-116.93-1.45z" filter="url(#aj)" fill="#2e3436"/>
 <path d="m47.518 184.59c-24.662 7.3484 30.107 42.063 53.215 48.765 47.108 13.663 77.728 17.467 144.85-25.938 27.101-23.941-19.54-25.35-81.132-21.376-104.14-5.57-111.78-21.09-116.93-1.45z" fill="url(#m)"/>


### PR DESCRIPTION
This optimizes our web version furthermore. I don't think we need to transfer
title and metadata each Foreman request, it stays in the originals tho.
